### PR TITLE
Fix AI tailor keyword bug; add checkout_started and trial_converted P…

### DIFF
--- a/app/components/subscribe-modal.tsx
+++ b/app/components/subscribe-modal.tsx
@@ -9,9 +9,10 @@ interface SubscribeModalProps {
 	successUrl: string
 	cancelUrl: string
 	redirectTo?: string
+	trigger?: 'download_limit' | 'ai_limit' | 'analysis_limit' | 'outreach_limit'
 }
 
-export function SubscribeModal({ isOpen, onClose, successUrl, cancelUrl, redirectTo }: SubscribeModalProps) {
+export function SubscribeModal({ isOpen, onClose, successUrl, cancelUrl, redirectTo, trigger }: SubscribeModalProps) {
 	return (
 		<Transition appear show={isOpen} as={Fragment}>
 			<Dialog as="div" className="relative z-50" onClose={onClose}>
@@ -53,7 +54,7 @@ export function SubscribeModal({ isOpen, onClose, successUrl, cancelUrl, redirec
 									Upgrade to Continue
 								</Dialog.Title>
 								<div>
-									<Pricing successUrl={successUrl} cancelUrl={cancelUrl} redirectTo={redirectTo} />
+									<Pricing successUrl={successUrl} cancelUrl={cancelUrl} redirectTo={redirectTo} trigger={trigger} />
 								</div>
 							</Dialog.Panel>
 						</Transition.Child>

--- a/app/lib/analytics.server.ts
+++ b/app/lib/analytics.server.ts
@@ -589,6 +589,7 @@ export function trackSubscriptionCreated(
 	plan: 'weekly' | 'monthly',
 	value: number,
 	currency: string = 'USD',
+	isFirstPayment: boolean = false,
 ): void {
 	trackServerEvent(
 		'subscription_created',
@@ -597,9 +598,24 @@ export function trackSubscriptionCreated(
 			value,
 			currency,
 			user_id: userId,
+			is_first_payment: isFirstPayment,
 		},
 		{ userId },
 	)
+
+	// Fire a dedicated event for trial-to-paid conversion (first payment only)
+	if (isFirstPayment) {
+		trackServerEvent(
+			'trial_converted',
+			{
+				plan,
+				value,
+				currency,
+				user_id: userId,
+			},
+			{ userId },
+		)
+	}
 
 	// Update user properties
 	identifyUser(userId, {

--- a/app/lib/analytics.types.ts
+++ b/app/lib/analytics.types.ts
@@ -211,7 +211,7 @@ export interface PaywallDismissedEvent {
 export interface CheckoutStartedEvent {
 	plan: 'weekly' | 'monthly'
 	is_trial: boolean
-	trigger: PaywallTrigger | 'direct'
+	trigger: PaywallTrigger | 'pricing_page' | 'direct'
 }
 
 export interface TrialStartedEvent {
@@ -220,6 +220,14 @@ export interface TrialStartedEvent {
 }
 
 export interface SubscriptionCreatedEvent {
+	plan: 'weekly' | 'monthly'
+	value: number
+	currency: string
+	user_id: string
+	is_first_payment: boolean
+}
+
+export interface TrialConvertedEvent {
 	plan: 'weekly' | 'monthly'
 	value: number
 	currency: string
@@ -393,6 +401,7 @@ export interface AnalyticsEventMap {
 	checkout_started: CheckoutStartedEvent
 	trial_started: TrialStartedEvent
 	subscription_created: SubscriptionCreatedEvent
+	trial_converted: TrialConvertedEvent
 	subscription_canceled: SubscriptionCanceledEvent
 
 	// Engagement

--- a/app/routes/builder+/index.tsx
+++ b/app/routes/builder+/index.tsx
@@ -733,6 +733,7 @@ export default function ResumeBuilder() {
 	const [scorePanel, setScorePanel] = useState(true)
 	const [activeSection, setActiveSection] = useState('experience')
 	const [showSubscribeModal, setShowSubscribeModal] = useState(false)
+	const [subscribeModalTrigger, setSubscribeModalTrigger] = useState<'download_limit' | 'ai_limit'>('download_limit')
 	const [showCreateJob, setShowCreateJob] = useState(false)
 	const [showCreationModal, setShowCreationModal] = useState(!formData.id)
 	const [showAIModal, setShowAIModal] = useState(false)
@@ -1631,6 +1632,7 @@ export default function ResumeBuilder() {
 			!subscription?.active &&
 			(gettingStartedProgress?.downloadCount ?? 0) >= MAX_FREE_DOWNLOADS
 		) {
+			setSubscribeModalTrigger('download_limit')
 			setShowSubscribeModal(true)
 			track('paywall_shown', {
 				trigger: 'download_limit',
@@ -2061,6 +2063,7 @@ export default function ResumeBuilder() {
 				successUrl="/builder"
 				redirectTo="/builder"
 				cancelUrl="/builder"
+				trigger={subscribeModalTrigger}
 			/>
 			<AIAssistantModal
 				isOpen={showAIModal}
@@ -2079,7 +2082,10 @@ export default function ResumeBuilder() {
 				resumeData={formData}
 				subscription={subscription}
 				gettingStartedProgress={gettingStartedProgress}
-				setShowSubscribeModal={setShowSubscribeModal}
+				setShowSubscribeModal={(show: boolean) => {
+					if (show) setSubscribeModalTrigger('ai_limit')
+					setShowSubscribeModal(show)
+				}}
 				onTailorClick={onboarding.handleTailorComplete}
 				theme={c}
 				diagnosticContext={diagnosticContext}

--- a/app/routes/resources+/builder-completions.ts
+++ b/app/routes/resources+/builder-completions.ts
@@ -226,6 +226,7 @@ export async function action({ request }: DataFunctionArgs) {
 					resumeData: parsedResumeForBullet,
 					user,
 					extractedKeywords: parsedKeywords,
+					diagnosticContext: parsedDiagnostic,
 				}),
 				await prisma.gettingStartedProgress.upsert({
 					where: { ownerId: userId },

--- a/app/routes/resources+/pricing.tsx
+++ b/app/routes/resources+/pricing.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react'
 import { Radio, RadioGroup } from '@headlessui/react'
 import { cn } from '~/utils/misc.ts'
 import { trackEvent } from '~/utils/analytics.ts'
+import { track } from '~/lib/analytics.client.ts'
 import type { loader as rootLoader } from '~/root.tsx'
 
 const frequencies = [
@@ -96,10 +97,12 @@ export function Pricing({
 	successUrl,
 	cancelUrl,
 	redirectTo,
+	trigger = 'pricing_page',
 }: {
 	successUrl: string
 	cancelUrl: string
 	redirectTo?: string | undefined
+	trigger?: 'pricing_page' | 'download_limit' | 'ai_limit' | 'analysis_limit' | 'outreach_limit' | 'direct'
 }) {
 	const [frequency, setFrequency] = useState(frequencies[0])
 	const rootData = useRouteLoaderData<typeof rootLoader>('root')
@@ -204,11 +207,11 @@ export function Pricing({
 													plan_tier: frequency.value,
 												})
 											}
-											// Track checkout_started event
-											trackEvent('checkout_started', {
+											// Track checkout_started event (PostHog)
+											track('checkout_started', {
 												plan: frequency.value,
 												is_trial: true,
-												trigger: 'pricing_page',
+												trigger,
 											})
 										}}
 										className={cn(

--- a/app/routes/resources+/stripe+/hook.tsx
+++ b/app/routes/resources+/stripe+/hook.tsx
@@ -210,6 +210,15 @@ async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
 		const planTier = isWeekly ? 'weekly' : 'monthly'
 		const priceUsd = isWeekly ? 4.99 : 15.0
 
+		// Check if this is the first payment (trial conversion) or a renewal
+		const existingPayments = await prisma.conversionEvent.count({
+			where: {
+				userId: subscription.ownerId,
+				eventType: 'purchase_completed',
+			},
+		})
+		const isFirstPayment = existingPayments === 0
+
 		// Create conversion event (tracked: false by default)
 		await prisma.conversionEvent.create({
 			data: {
@@ -228,9 +237,10 @@ async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
 			planTier as 'weekly' | 'monthly',
 			priceUsd,
 			'USD',
+			isFirstPayment,
 		)
 
-		console.log(`Created conversion event for user ${subscription.ownerId}`)
+		console.log(`Created ${isFirstPayment ? 'first payment (trial conversion)' : 'renewal'} event for user ${subscription.ownerId}`)
 	} catch (e) {
 		console.error('Error handling invoice.payment_succeeded', e)
 		throw e


### PR DESCRIPTION
…ostHog events

- Pass diagnosticContext to getBuilderExperienceResponse so keyword instructions reach the AI prompt (fixes tailor loop bug)
- Route checkout_started from GA4-only to PostHog with trigger property (pricing_page, download_limit, ai_limit)
- Add trial_converted event that fires only on first payment after trial
- Add is_first_payment flag to subscription_created to distinguish renewals from conversions

<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
