### PR TITLE
fix: builder UX bugs — yes button styling, validation gate, skip undo

### DIFF
--- a/app/components/truth-panel.tsx
+++ b/app/components/truth-panel.tsx
@@ -112,12 +112,16 @@ function ConversationLayer({
 		setAnswers(prev => { const next = new Map(prev); next.delete(i); return next })
 	}
 
-	const allAnswered = answers.size === requirements.length
 	const yesItems = requirements
 		.map((req, i) => ({ req, ans: answers.get(i) }))
 		.filter((x): x is { req: string; ans: { yes: true; experienceId: string } } => !!x.ans?.yes && !!x.ans.experienceId)
 		.map(x => ({ requirement: x.req, experienceId: x.ans.experienceId }))
-	const noItems = requirements.filter((_, i) => answers.get(i)?.yes === false)
+	// Unanswered questions are treated as "No" when proceeding
+	const noItems = requirements.filter((_, i) => {
+		const ans = answers.get(i)
+		return !ans || ans.yes === false
+	})
+	const canProceed = yesItems.length > 0
 
 	return (
 		<div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -173,9 +177,9 @@ function ConversationLayer({
 											style={{
 												padding: '8px 16px',
 												borderRadius: 8,
-												border: `1px solid ${BRAND}`,
+												border: `1px solid ${c.border}`,
 												background: 'transparent',
-												color: BRAND,
+												color: c.text,
 												fontSize: 13,
 												fontWeight: 600,
 												cursor: 'pointer',
@@ -190,7 +194,7 @@ function ConversationLayer({
 												borderRadius: 8,
 												border: `1px solid ${c.border}`,
 												background: 'transparent',
-												color: c.dim,
+												color: c.text,
 												fontSize: 13,
 												fontWeight: 600,
 												cursor: 'pointer',
@@ -228,7 +232,7 @@ function ConversationLayer({
 				)
 			})}
 
-			{allAnswered && yesItems.length > 0 && (
+			{canProceed && (
 				<button
 					onClick={() => onDone(yesItems, noItems)}
 					style={{
@@ -247,7 +251,7 @@ function ConversationLayer({
 					Add {yesItems.length} to my resume →
 				</button>
 			)}
-			{allAnswered && yesItems.length === 0 && (
+			{answers.size === requirements.length && yesItems.length === 0 && (
 				<div style={{ fontSize: 13, color: c.dim, marginTop: 4 }}>
 					These appear to be genuine gaps in your background for this role.
 				</div>

--- a/app/components/ui/toast.tsx
+++ b/app/components/ui/toast.tsx
@@ -13,7 +13,7 @@ const ToastViewport = React.forwardRef<
 	<ToastPrimitives.Viewport
 		ref={ref}
 		className={cn(
-			'fixed top-0 z-[400] flex max-h-screen w-full flex-col-reverse gap-2 p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+			'fixed top-0 z-[400] flex max-h-screen w-full flex-col-reverse gap-2 p-4 sm:bottom-20 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
 			className,
 		)}
 		{...props}

--- a/app/routes/builder+/index.tsx
+++ b/app/routes/builder+/index.tsx
@@ -65,6 +65,7 @@ import { trackEvent } from '~/utils/analytics.ts'
 import { trackEvent as trackLegacyEvent } from '~/utils/tracking.client.ts'
 import { track } from '~/lib/analytics.client.ts'
 import { toast } from '~/components/ui/use-toast.ts'
+import { ToastAction } from '~/components/ui/toast.tsx'
 import { useOnboardingFlow } from '~/hooks/use-onboarding-flow.ts'
 import { JobPasteModal } from '~/components/job-paste-modal.tsx'
 import { BuilderNav } from '~/components/builder-nav.tsx'
@@ -607,6 +608,7 @@ export default function ResumeBuilder() {
 	const [editingResumeId, setEditingResumeId] = useState<string | null>(null)
 	const [matchRefetchKey, setMatchRefetchKey] = useState(0)
 	const undoSnapshotRef = useRef<typeof formData | null>(null)
+	const skipUndoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 	const bulletUndoMapRef = useRef<Map<string, { action: 'rewrite' | 'new'; experienceId: string; originalText: string | null }>>(new Map())
 	const [pendingHighlights, setPendingHighlights] = useState<string[]>([])
 	const [coachStep, setCoachStep] = useState<number | null>(null)
@@ -638,6 +640,13 @@ export default function ResumeBuilder() {
 	}, [])
 	const canvasAvailable = viewportWidth - sW - rightPanelW - 80
 	const canvasScale = Math.min(Math.max(canvasAvailable / 816, 0.7), 1.25)
+
+	// Clean up skip-role undo timer on unmount
+	useEffect(() => {
+		return () => {
+			if (skipUndoTimerRef.current) clearTimeout(skipUndoTimerRef.current)
+		}
+	}, [])
 
 	/* ═══ DARK MODE (synced with app theme) ═══ */
 	const themeFetcher = useFetcher()
@@ -2723,7 +2732,22 @@ export default function ResumeBuilder() {
 								}
 							} : undefined}
 							onSkipRole={() => {
+								const skippedJob = selectedJob
 								setSelectedJob(null)
+								if (skipUndoTimerRef.current) clearTimeout(skipUndoTimerRef.current)
+								const { dismiss } = toast({
+									title: 'Role skipped',
+									action: <ToastAction altText="Undo skip" onClick={() => {
+										if (skipUndoTimerRef.current) clearTimeout(skipUndoTimerRef.current)
+										skipUndoTimerRef.current = null
+										setSelectedJob(skippedJob ?? null)
+										dismiss()
+									}}>Undo</ToastAction>,
+								})
+								skipUndoTimerRef.current = setTimeout(() => {
+									skipUndoTimerRef.current = null
+									dismiss()
+								}, 5000)
 							}}
 							onDownload={handleDownloadPDF}
 							onNextJob={() => {


### PR DESCRIPTION
- Neutralize Yes/No button default styling so neither appears preselected
- Allow proceeding after ≥1 yes with role selected, unanswered default to No
- Add 5s undo toast after Skip Role with cleanup on unmount
- Raise toast viewport above Crisp chat button

<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
