### PR TITLE
fix: builder UX audit — 30+ fixes across 6 waves

### DIFF
--- a/app/components/ai-assistant-modal.tsx
+++ b/app/components/ai-assistant-modal.tsx
@@ -203,9 +203,8 @@ export function AIAssistantModal({
 			setTailorContent(content)
 			setTailorExperience(experience)
 			setShowBulletPicker(!content)
+			setActiveTab(initialTab ?? 'tailor')
 			if (!wasOpenRef.current) {
-				// Modal just opened — reset tab and track
-				setActiveTab(initialTab ?? 'tailor')
 				trackAiModalOpened(initialTab ?? 'tailor', experience?.id ?? undefined)
 				wasOpenRef.current = true
 			}

--- a/app/components/builder-nav.tsx
+++ b/app/components/builder-nav.tsx
@@ -6,10 +6,12 @@ import {
 	Moon,
 	Download,
 	Check,
+	AlertTriangle,
 	Palette,
 	LogOut,
 	User as UserIcon,
 	CreditCard,
+	HelpCircle,
 } from 'lucide-react'
 import { getUserImgSrc } from '~/utils/misc.ts'
 
@@ -51,6 +53,7 @@ export interface BuilderNavProps {
 	manageSubFormRef: React.RefObject<HTMLFormElement>
 	submitForm: (form: HTMLFormElement | null) => void
 	navigate: (to: string) => void
+	onReplayWalkthrough?: () => void
 	BRAND: string
 	AMBER: string
 	SUCCESS: string
@@ -77,10 +80,12 @@ export function BuilderNav({
 	manageSubFormRef,
 	submitForm,
 	navigate,
+	onReplayWalkthrough,
 	BRAND,
 	AMBER,
 	SUCCESS,
 }: BuilderNavProps) {
+	const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform)
 	return (
 		<div
 			style={{
@@ -152,7 +157,7 @@ export function BuilderNav({
 						fontFamily: 'system-ui',
 					}}
 				>
-					⌘K
+					{isMac ? '⌘K' : 'Ctrl+K'}
 				</span>
 			</div>
 			<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -164,6 +169,8 @@ export function BuilderNav({
 								? AMBER
 								: saveStatus === 'saved'
 								? SUCCESS
+								: saveStatus === 'error'
+								? '#ef4444'
 								: c.dim,
 						display: 'flex',
 						alignItems: 'center',
@@ -171,7 +178,8 @@ export function BuilderNav({
 						transition: 'color 300ms',
 					}}
 				>
-					<Check size={12} strokeWidth={2} />
+					{saveStatus === 'saved' && <Check size={12} strokeWidth={2} />}
+					{saveStatus === 'error' && <AlertTriangle size={12} strokeWidth={2} />}
 					{saveStatus === 'saving'
 						? 'Saving...'
 						: saveStatus === 'saved'
@@ -198,6 +206,25 @@ export function BuilderNav({
 					<Palette size={14} color={c.dim} strokeWidth={1.75} />
 					Customize
 				</button>
+				{onReplayWalkthrough && (
+					<button
+						onClick={onReplayWalkthrough}
+						title="Replay walkthrough"
+						style={{
+							width: 32,
+							height: 32,
+							borderRadius: 6,
+							border: 'none',
+							background: 'transparent',
+							cursor: 'pointer',
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+						}}
+					>
+						<HelpCircle size={16} color={c.dim} strokeWidth={1.75} />
+					</button>
+				)}
 				<button
 					onClick={toggleDarkMode}
 					style={{

--- a/app/components/cover-letter-panel.tsx
+++ b/app/components/cover-letter-panel.tsx
@@ -102,13 +102,13 @@ export function CoverLetterPanel({
 						Back to Assessment
 					</span>
 				</button>
-				<div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+				<div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
 					<button
 						onClick={onRegenerate}
 						disabled={isGenerating}
 						title="Regenerate"
 						style={{
-							padding: 8,
+							padding: '6px 12px',
 							borderRadius: 8,
 							border: 'none',
 							background: 'transparent',
@@ -116,8 +116,10 @@ export function CoverLetterPanel({
 							color: c.dim,
 							display: 'flex',
 							alignItems: 'center',
-							justifyContent: 'center',
+							gap: 6,
 							opacity: isGenerating ? 0.5 : 1,
+							fontSize: 12,
+							fontWeight: 500,
 						}}
 						onMouseEnter={e => {
 							;(e.currentTarget as HTMLButtonElement).style.background = c.bgSurf
@@ -126,14 +128,15 @@ export function CoverLetterPanel({
 							;(e.currentTarget as HTMLButtonElement).style.background = 'transparent'
 						}}
 					>
-						<RefreshCw size={16} strokeWidth={1.75} />
+						<RefreshCw size={14} strokeWidth={1.75} />
+						<span>Regenerate</span>
 					</button>
 					<button
 						onClick={handleCopy}
 						disabled={!coverLetterText}
 						title="Copy"
 						style={{
-							padding: 8,
+							padding: '6px 12px',
 							borderRadius: 8,
 							border: 'none',
 							background: 'transparent',
@@ -141,8 +144,10 @@ export function CoverLetterPanel({
 							color: c.dim,
 							display: 'flex',
 							alignItems: 'center',
-							justifyContent: 'center',
+							gap: 6,
 							opacity: coverLetterText ? 1 : 0.5,
+							fontSize: 12,
+							fontWeight: 500,
 						}}
 						onMouseEnter={e => {
 							;(e.currentTarget as HTMLButtonElement).style.background = c.bgSurf
@@ -151,14 +156,15 @@ export function CoverLetterPanel({
 							;(e.currentTarget as HTMLButtonElement).style.background = 'transparent'
 						}}
 					>
-						<Copy size={16} strokeWidth={1.75} />
+						<Copy size={14} strokeWidth={1.75} />
+						<span>Copy</span>
 					</button>
 					<button
 						onClick={handleDownload}
 						disabled={!coverLetterText}
 						title="Download"
 						style={{
-							padding: 8,
+							padding: '6px 12px',
 							borderRadius: 8,
 							border: 'none',
 							background: 'transparent',
@@ -166,8 +172,10 @@ export function CoverLetterPanel({
 							color: c.dim,
 							display: 'flex',
 							alignItems: 'center',
-							justifyContent: 'center',
+							gap: 6,
 							opacity: coverLetterText ? 1 : 0.5,
+							fontSize: 12,
+							fontWeight: 500,
 						}}
 						onMouseEnter={e => {
 							;(e.currentTarget as HTMLButtonElement).style.background = c.bgSurf
@@ -176,7 +184,8 @@ export function CoverLetterPanel({
 							;(e.currentTarget as HTMLButtonElement).style.background = 'transparent'
 						}}
 					>
-						<Download size={16} strokeWidth={1.75} />
+						<Download size={14} strokeWidth={1.75} />
+						<span>Download</span>
 					</button>
 				</div>
 			</div>
@@ -242,7 +251,7 @@ export function CoverLetterPanel({
 					<textarea
 						value={coverLetterText}
 						onChange={e => onTextChange(e.target.value)}
-						placeholder="Your cover letter will appear here..."
+						placeholder="Your cover letter will appear here. You can edit it directly."
 						style={{
 							flex: 1,
 							fontFamily: 'Crimson Pro, Georgia, serif',

--- a/app/components/create-job-modal.tsx
+++ b/app/components/create-job-modal.tsx
@@ -104,6 +104,7 @@ export function CreateJobModal({ isOpen, onClose, onCreate, theme, showSkip, onS
 								Job Title
 							</label>
 							<input
+								autoFocus
 								type="text"
 								id="title"
 								name="title"

--- a/app/components/floating-toolbar.tsx
+++ b/app/components/floating-toolbar.tsx
@@ -100,7 +100,7 @@ export function FloatingToolbar({
 					key: 'addBullet',
 					label: 'Add bullet below',
 					icon: Plus,
-					action: { type: 'addBullet', experienceId: hovered.experienceId! },
+					action: { type: 'addBullet', experienceId: hovered.experienceId!, afterIndex: hovered.bulletIndex! },
 				})
 				const bulletContent = exp?.descriptions?.[hovered.bulletIndex!]?.content?.trim() ?? ''
 				items.push({

--- a/app/components/floating-toolbar.tsx
+++ b/app/components/floating-toolbar.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useRef, useEffect } from 'react'
 import {
 	ChevronUp,
 	ChevronDown,
@@ -54,6 +54,14 @@ export function FloatingToolbar({
 	sectionOrder,
 	formData,
 }: FloatingToolbarProps) {
+	const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
+
+	useEffect(() => {
+		return () => {
+			if (dismissTimeoutRef.current) clearTimeout(dismissTimeoutRef.current)
+		}
+	}, [])
+
 	const actions = useMemo((): ToolbarAction[] => {
 		if (!hovered) return []
 
@@ -94,9 +102,10 @@ export function FloatingToolbar({
 					icon: Plus,
 					action: { type: 'addBullet', experienceId: hovered.experienceId! },
 				})
+				const bulletContent = exp?.descriptions?.[hovered.bulletIndex!]?.content?.trim() ?? ''
 				items.push({
 					key: 'aiTailor',
-					label: 'AI tailor',
+					label: bulletContent ? 'Rewrite' : 'Generate',
 					icon: Sparkles,
 					action: { type: '__aiTailor' },
 				})
@@ -271,15 +280,28 @@ export function FloatingToolbar({
 		<div
 			style={style}
 			onMouseDown={(e) => e.preventDefault()}
-			onMouseEnter={() => { if (toolbarHoveredRef) (toolbarHoveredRef as React.MutableRefObject<boolean>).current = true }}
-			onMouseLeave={() => { if (toolbarHoveredRef) { (toolbarHoveredRef as React.MutableRefObject<boolean>).current = false; onDismiss?.() } }}
+			onMouseEnter={() => {
+				if (toolbarHoveredRef) (toolbarHoveredRef as React.MutableRefObject<boolean>).current = true
+				if (dismissTimeoutRef.current) clearTimeout(dismissTimeoutRef.current)
+			}}
+			onMouseLeave={() => {
+				if (toolbarHoveredRef) (toolbarHoveredRef as React.MutableRefObject<boolean>).current = false
+				dismissTimeoutRef.current = setTimeout(() => {
+					if (toolbarHoveredRef && !toolbarHoveredRef.current) {
+						onDismiss?.()
+					}
+				}, 150)
+			}}
+			onKeyDown={(e) => {
+				if (e.key === 'Escape') onDismiss?.()
+			}}
 			role="toolbar"
 			aria-label="Element actions"
 		>
 			<style>{`
 				.floating-toolbar-wrap {
 					display: flex;
-					flex-direction: column;
+					flex-direction: row;
 					gap: 2px;
 					background: #fff;
 					border-radius: 8px;
@@ -313,9 +335,20 @@ export function FloatingToolbar({
 					background: #fef2f2;
 					color: #dc2626;
 				}
+				.floating-toolbar-btn.ai {
+					background: #6B45FF;
+					color: #fff;
+					width: auto;
+					min-width: 26px;
+					padding: 0 7px;
+					gap: 4px;
+					font-size: 10px;
+					font-weight: 600;
+					letter-spacing: 0.02em;
+				}
 				.floating-toolbar-btn.ai:hover:not(:disabled) {
-					background: #f5f3ff;
-					color: #7c3aed;
+					background: #5A37E0;
+					color: #fff;
 				}
 			`}</style>
 			<div className="floating-toolbar-wrap">
@@ -329,6 +362,7 @@ export function FloatingToolbar({
 						aria-label={a.label}
 					>
 						<a.icon size={14} />
+						{a.key === 'aiTailor' && <span>{a.label}</span>}
 					</button>
 				))}
 			</div>

--- a/app/components/onboarding-widget.tsx
+++ b/app/components/onboarding-widget.tsx
@@ -8,6 +8,7 @@ import {
 } from 'lucide-react'
 
 const BRAND = '#6B45FF'
+const BRAND_LIGHT = '#A78BFA'
 const SUCCESS = '#30A46C'
 
 export interface OnboardingWidgetProps {
@@ -51,64 +52,97 @@ export function OnboardingWidget({
 		{
 			id: 'resume',
 			label: 'Create a resume',
-			done: !!(hasResume),
+			done: !!hasResume,
 			action: onResumeClick,
+			locked: false,
 		},
 		{
 			id: 'job',
 			label: 'Add a target job',
 			done: !!hasJob,
 			action: onJobClick,
+			locked: !hasResume,
 		},
 		{
 			id: 'match',
 			label: 'Review your match',
 			done: hasReviewedMatch,
 			action: undefined,
+			locked: !hasJob,
 		},
 		{
 			id: 'action',
-			label: 'Take your first action',
+			label: 'Tailor a bullet with AI',
 			done: hasTakenAction,
 			action: undefined,
+			locked: !hasReviewedMatch,
 		},
 	]
+
+	// The first incomplete, unlocked step gets the shimmer
+	const activeStepId = steps.find(s => !s.done && !s.locked)?.id ?? null
+
+	const doneCount = steps.filter(s => s.done).length
+	const progress = (doneCount / steps.length) * 100
 
 	return (
 		<div
 			style={{
-				position: 'fixed',
-				bottom: 20,
-				right: 20,
-				zIndex: 150,
-				width: collapsed ? 48 : 280,
+				marginTop: 'auto',
+				borderTop: `1px solid ${c.border}`,
 				background: c.bgEl,
-				borderRadius: 12,
-				border: `1px solid ${c.border}`,
-				boxShadow: '0 8px 32px rgba(0,0,0,0.15)',
 				overflow: 'hidden',
-				transition: 'width 200ms',
 			}}
 		>
+			<style>{`
+				@keyframes onboarding-shimmer {
+					0% { background-position: 100% 0; }
+					100% { background-position: -100% 0; }
+				}
+				.onboarding-shimmer-text {
+					background: linear-gradient(
+						90deg,
+						${BRAND} 0%,
+						${BRAND} 40%,
+						${BRAND_LIGHT} 50%,
+						#C4B5FD 55%,
+						${BRAND_LIGHT} 60%,
+						${BRAND} 70%,
+						${BRAND} 100%
+					);
+					background-size: 200% 100%;
+					-webkit-background-clip: text;
+					background-clip: text;
+					-webkit-text-fill-color: transparent;
+					animation: onboarding-shimmer 2.5s ease-in-out infinite;
+					font-weight: 600;
+				}
+			`}</style>
+
 			{collapsed ? (
 				<div
 					onClick={() => setCollapsed(false)}
 					style={{
-						width: 48,
-						height: 48,
+						padding: '10px 16px',
 						display: 'flex',
 						alignItems: 'center',
-						justifyContent: 'center',
+						gap: 8,
 						cursor: 'pointer',
 					}}
 				>
-					<Rocket size={20} color={c.brandText} strokeWidth={1.75} />
+					<Rocket size={16} color={c.brandText} strokeWidth={1.75} />
+					<span style={{ fontSize: 14, fontWeight: 600, color: c.text }}>
+						Getting Started
+					</span>
+					<span style={{ fontSize: 12, color: '#454550', marginLeft: 'auto' }}>
+						{doneCount}/{steps.length}
+					</span>
 				</div>
 			) : (
 				<>
 					<div
 						style={{
-							padding: '12px 16px 8px',
+							padding: '14px 16px 8px',
 							display: 'flex',
 							alignItems: 'center',
 							justifyContent: 'space-between',
@@ -116,9 +150,7 @@ export function OnboardingWidget({
 					>
 						<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
 							<Rocket size={16} color={c.brandText} strokeWidth={1.75} />
-							<span
-								style={{ fontSize: 13, fontWeight: 600, color: c.text }}
-							>
+							<span style={{ fontSize: 15, fontWeight: 700, color: c.text }}>
 								Getting Started
 							</span>
 						</div>
@@ -158,50 +190,58 @@ export function OnboardingWidget({
 						</div>
 					</div>
 					<div style={{ padding: '4px 16px 16px' }}>
-						{steps.map(step => (
-							<div
-								key={step.id}
-								onClick={!step.done ? step.action : undefined}
-								style={{
-									display: 'flex',
-									alignItems: 'center',
-									gap: 10,
-									padding: '8px 0',
-									cursor: step.done ? 'default' : 'pointer',
-									opacity: step.done ? 0.6 : 1,
-								}}
-							>
-								{step.done ? (
-									<CheckCircle2
-										size={16}
-										color={SUCCESS}
-										strokeWidth={1.75}
-									/>
-								) : (
-									<Circle size={16} color={c.dim} strokeWidth={1.75} />
-								)}
-								<span
+						{steps.map(step => {
+							const isActive = step.id === activeStepId
+							return (
+								<div
+									key={step.id}
+									onClick={!step.done && !step.locked ? step.action : undefined}
+									title={step.locked ? 'Complete the previous step first' : undefined}
 									style={{
-										fontSize: 13,
-										color: step.done ? c.dim : c.text,
-										textDecoration: step.done ? 'line-through' : 'none',
+										display: 'flex',
+										alignItems: 'center',
+										gap: 10,
+										padding: '9px 0',
+										cursor: step.done || step.locked ? 'default' : 'pointer',
 									}}
 								>
-									{step.label}
-								</span>
-								{!step.done && (
-									<ChevronRight
-										size={12}
-										color={c.dim}
-										style={{ marginLeft: 'auto' }}
-									/>
-								)}
-							</div>
-						))}
+									{step.done ? (
+										<CheckCircle2
+											size={18}
+											color={SUCCESS}
+											strokeWidth={1.75}
+										/>
+									) : isActive ? (
+										<Circle size={18} color={BRAND} strokeWidth={2} />
+									) : (
+										<Circle size={18} color={step.locked ? c.border : c.dim} strokeWidth={1.75} />
+									)}
+									<span
+										className={isActive ? 'onboarding-shimmer-text' : undefined}
+										style={{
+											fontSize: 15,
+											color: step.locked ? c.border : step.done ? c.dim : isActive ? BRAND : c.text,
+											textDecoration: step.done ? 'line-through' : 'none',
+											fontWeight: isActive ? 600 : 500,
+											opacity: step.locked ? 0.5 : 1,
+										}}
+									>
+										{step.label}
+									</span>
+									{isActive && (
+										<ChevronRight
+											size={13}
+											color={BRAND}
+											style={{ marginLeft: 'auto' }}
+										/>
+									)}
+								</div>
+							)
+						})}
 						{/* Progress bar */}
 						<div
 							style={{
-								marginTop: 8,
+								marginTop: 10,
 								height: 3,
 								borderRadius: 2,
 								background: c.border,
@@ -214,9 +254,7 @@ export function OnboardingWidget({
 									borderRadius: 2,
 									background: BRAND,
 									transition: 'width 300ms',
-									width: `${
-										(steps.filter(s => s.done).length / steps.length) * 100
-									}%`,
+									width: `${progress}%`,
 								}}
 							/>
 						</div>

--- a/app/components/resume-creation-modal.tsx
+++ b/app/components/resume-creation-modal.tsx
@@ -1,5 +1,5 @@
 import { useFetcher } from '@remix-run/react'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { type ResumeData } from '~/utils/builder-resume.server.ts'
 import { X, FilePlus, Upload, Copy, Loader2, ChevronRight, Check } from 'lucide-react'
 
@@ -45,8 +45,37 @@ export function ResumeCreationModal({
 	const fileInputRef = useRef<HTMLInputElement>(null)
 	const [selectedResumeId, setSelectedResumeId] = useState<string | null>(null)
 	const [showResumes, setShowResumes] = useState(false)
+	const [uploadError, setUploadError] = useState<string | null>(null)
 
 	const isSubmitting = fetcher.state !== 'idle'
+
+	const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+	const ALLOWED_TYPES = [
+		'application/pdf',
+		'application/msword',
+		'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+	]
+	const ALLOWED_EXTENSIONS = ['.pdf', '.doc', '.docx']
+
+	// Watch fetcher.data for server errors
+	useEffect(() => {
+		if (fetcher.data && typeof fetcher.data === 'object' && 'error' in fetcher.data) {
+			const errorMsg = (fetcher.data as { error: string }).error
+			setUploadError(errorMsg)
+		}
+	}, [fetcher.data])
+
+	// Auto-clear error after 10 seconds
+	useEffect(() => {
+		if (!uploadError) return
+		const timer = setTimeout(() => setUploadError(null), 10_000)
+		return () => clearTimeout(timer)
+	}, [uploadError])
+
+	// Clear error when modal closes
+	useEffect(() => {
+		if (!isOpen) setUploadError(null)
+	}, [isOpen])
 
 	const handleClickUpload = () => {
 		const isLoggedInAndHasSubscription = handleUploadResume()
@@ -58,6 +87,23 @@ export function ResumeCreationModal({
 	const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const file = e.target.files?.[0]
 		if (!file) return
+
+		setUploadError(null)
+
+		// Client-side file size validation
+		if (file.size > MAX_FILE_SIZE) {
+			setUploadError('File exceeds 5MB limit')
+			if (fileInputRef.current) fileInputRef.current.value = ''
+			return
+		}
+
+		// Client-side file type validation
+		const ext = file.name.toLowerCase().slice(file.name.lastIndexOf('.'))
+		if (!ALLOWED_TYPES.includes(file.type) && !ALLOWED_EXTENSIONS.includes(ext)) {
+			setUploadError('Please upload a PDF or DOCX file')
+			if (fileInputRef.current) fileInputRef.current.value = ''
+			return
+		}
 
 		const formData = new FormData()
 		formData.append('resumeFile', file)
@@ -148,6 +194,44 @@ export function ResumeCreationModal({
 						onChange={handleFileChange}
 						accept=".doc, .docx, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/pdf, image/png, image/jpeg, .txt"
 					/>
+
+					{uploadError && (
+						<div style={{
+							background: '#FEE2E2',
+							color: '#991B1B',
+							borderRadius: 8,
+							padding: '10px 14px',
+							marginBottom: 6,
+							fontSize: 13,
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'space-between',
+							gap: 10,
+						}}>
+							<span>{uploadError}</span>
+							<button
+								type="button"
+								onClick={() => {
+									setUploadError(null)
+									if (fileInputRef.current) fileInputRef.current.value = ''
+									fileInputRef.current?.click()
+								}}
+								style={{
+									background: 'transparent',
+									border: 'none',
+									color: '#991B1B',
+									fontWeight: 600,
+									fontSize: 13,
+									cursor: 'pointer',
+									whiteSpace: 'nowrap',
+									textDecoration: 'underline',
+									padding: 0,
+								}}
+							>
+								Try again
+							</button>
+						</div>
+					)}
 
 					<div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
 						{!showResumes && (

--- a/app/components/resume-iframe.tsx
+++ b/app/components/resume-iframe.tsx
@@ -12,7 +12,7 @@ import { generateResumeHtml } from '~/utils/generate-resume-html.ts'
 import type { ResumeData } from '~/utils/builder-resume.server.ts'
 
 export type StructuralAction =
-	| { type: 'addBullet'; experienceId: string }
+	| { type: 'addBullet'; experienceId: string; afterIndex?: number }
 	| { type: 'deleteBullet'; experienceId: string; bulletIndex: number }
 	| { type: 'reorderBullet'; experienceId: string; oldIndex: number; newIndex: number }
 	| { type: 'addExperience' }

--- a/app/components/subscribe-modal.tsx
+++ b/app/components/subscribe-modal.tsx
@@ -31,7 +31,7 @@ export function SubscribeModal({ isOpen, onClose, successUrl, cancelUrl, redirec
 
 	return (
 		<Transition appear show={isOpen} as={Fragment}>
-			<Dialog as="div" className="relative z-50" onClose={handleClose}>
+			<Dialog as="div" className="relative z-[200]" onClose={handleClose}>
 				<Transition.Child
 					as={Fragment}
 					enter="ease-out duration-300"

--- a/app/components/truth-panel.tsx
+++ b/app/components/truth-panel.tsx
@@ -44,9 +44,13 @@ interface TruthPanelProps {
 	onNextJob?: () => void
 	hasCoverLetter?: boolean
 	refetchKey?: number
+	resumeChanged?: boolean
+	onRefreshMatch?: () => void
+	/** When true, skip conversation and show summary-only verdict after re-analysis */
+	postTailorMode?: boolean
 }
 
-type Layer = 'verdict' | 'conversation' | 'generating' | 'done' | 'analysis'
+type Layer = 'verdict' | 'conversation' | 'generating' | 'done' | 'analysis' | 'post-tailor-loading' | 'post-tailor-result'
 
 function getLevelColor(level: ExperienceMatch['level']): string {
 	switch (level) {
@@ -320,11 +324,15 @@ export function TruthPanel({
 	onNextJob,
 	hasCoverLetter,
 	refetchKey,
+	resumeChanged,
+	onRefreshMatch,
+	postTailorMode,
 }: TruthPanelProps) {
 	const fetcher = useFetcher<ExperienceMatch>()
 	const bulletFetcher = useFetcher<{ bullets: GeneratedBullet[] }>()
 	const prevJobIdRef = useRef<string | null>(null)
 	const matchLoadedCalledRef = useRef(false)
+	const hasAutoExpandedRef = useRef(false)
 	const [layer, setLayer] = useState<Layer>('verdict')
 	const [lastGaps, setLastGaps] = useState<string[]>([])
 	const [lastAlreadyCovered, setLastAlreadyCovered] = useState<string[]>([])
@@ -338,6 +346,7 @@ export function TruthPanel({
 		setLastAlreadyCovered([])
 		setLastAddedCount(0)
 		setLastWarnings([])
+		hasAutoExpandedRef.current = false
 	}, [selectedJob?.id])
 
 	useEffect(() => {
@@ -363,12 +372,58 @@ export function TruthPanel({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [refetchKey])
 
+	// Post-tailor: auto re-analyze after tailor changes are applied
+	const postTailorTriggeredRef = useRef(false)
+	const awaitingPostTailorRef = useRef(false)
 	useEffect(() => {
-		if (fetcher.data && !matchLoadedCalledRef.current) {
+		if (postTailorMode && !postTailorTriggeredRef.current && selectedJob?.id && formData.id) {
+			postTailorTriggeredRef.current = true
+			awaitingPostTailorRef.current = true
+			setLayer('post-tailor-loading')
+			prevJobIdRef.current = null
+			fetcher.submit(
+				JSON.stringify({ resumeId: formData.id, jobId: selectedJob.id }),
+				{ method: 'POST', action: '/resources/experience-match', encType: 'application/json' },
+			)
+		}
+		if (!postTailorMode) {
+			postTailorTriggeredRef.current = false
+		}
+	}, [postTailorMode, selectedJob?.id, formData.id, fetcher])
+
+	// Watch fetcher state transitions to detect when NEW data arrives
+	const prevFetcherStateRef = useRef(fetcher.state)
+	useEffect(() => {
+		const wasLoading = prevFetcherStateRef.current !== 'idle'
+		const isNowIdle = fetcher.state === 'idle'
+		prevFetcherStateRef.current = fetcher.state
+
+		// Only fire when transitioning from loading → idle (new data arrived)
+		if (!wasLoading || !isNowIdle || !fetcher.data) return
+
+		// Post-tailor: skip conversation, show result
+		if (awaitingPostTailorRef.current) {
+			awaitingPostTailorRef.current = false
+			onMatchLoaded?.()
+			setLayer('post-tailor-result')
+			return
+		}
+
+		if (!matchLoadedCalledRef.current) {
 			matchLoadedCalledRef.current = true
 			onMatchLoaded?.()
+
+			// Auto-expand into conversation if there are missing requirements to address
+			const data = fetcher.data as ExperienceMatch & { error?: string } | undefined
+			if (data && !('error' in data)) {
+				const missing = data.missingRequirements ?? []
+				if (missing.length > 0 && data.level !== 'mismatch' && !hasAutoExpandedRef.current) {
+					hasAutoExpandedRef.current = true
+					setLayer('conversation')
+				}
+			}
 		}
-	}, [fetcher.data, onMatchLoaded])
+	}, [fetcher.state, fetcher.data, onMatchLoaded])
 
 	// When bullets arrive, convert and call parent
 	const bulletDataProcessedRef = useRef<unknown>(null)
@@ -456,11 +511,39 @@ export function TruthPanel({
 	const isError = !isLoading && (!rawData || 'error' in rawData) && fetcher.state === 'idle' && prevJobIdRef.current !== null && selectedJob !== null
 	const match = rawData && !('error' in rawData) ? rawData as ExperienceMatch : undefined
 
-	/* ═══ Empty ═══ */
-	if (!selectedJob) {
+	/* ═══ Empty-state matrix ═══ */
+	const hasContent = !!(
+		(formData.about && formData.about.trim().length > 0) ||
+		(formData.experiences ?? []).some(exp =>
+			(exp.descriptions ?? []).some(d => d.content && d.content.trim().length > 0)
+		)
+	)
+	const hasJob = !!selectedJob
+
+	if (!hasContent || !hasJob) {
+		const message = !hasContent && !hasJob
+			? 'Add your experience and a target job to see your match analysis'
+			: hasContent && !hasJob
+				? 'Add a target job to see your match'
+				: 'Add your experience to see your match'
 		return (
-			<div style={{ padding: 32, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', textAlign: 'center' }}>
-				<div style={{ fontSize: 16, fontWeight: 500, color: c.muted }}>Paste a job description to get started</div>
+			<div style={{
+				padding: 32,
+				display: 'flex',
+				flexDirection: 'column',
+				alignItems: 'center',
+				justifyContent: 'center',
+				height: '100%',
+				textAlign: 'center',
+			}}>
+				<div style={{
+					fontSize: 15,
+					fontWeight: 500,
+					color: c.muted,
+					lineHeight: 1.6,
+				}}>
+					{message}
+				</div>
 			</div>
 		)
 	}
@@ -474,6 +557,9 @@ export function TruthPanel({
 				<SkeletonBlock width="70%" height={40} c={c} />
 				<SkeletonBlock width="100%" height={16} c={c} />
 				<div style={{ marginTop: 12 }}><SkeletonBlock width="80%" height={36} c={c} /></div>
+				<div style={{ fontSize: 13, color: c.muted, marginTop: 4 }}>
+					Analyzing your resume against this job...
+				</div>
 			</div>
 		)
 	}
@@ -499,6 +585,37 @@ export function TruthPanel({
 		)
 	}
 
+	// #28-29: Resume changed banner
+	const refreshBanner = resumeChanged && onRefreshMatch && !postTailorMode && layer !== 'post-tailor-loading' && layer !== 'post-tailor-result' ? (
+		<div style={{
+			padding: '10px 16px',
+			background: '#FFF7ED',
+			borderBottom: `1px solid ${c.border}`,
+			display: 'flex',
+			alignItems: 'center',
+			justifyContent: 'space-between',
+			gap: 8,
+		}}>
+			<span style={{ fontSize: 13, color: '#9A3412', fontWeight: 500 }}>Resume changed since last analysis</span>
+			<button
+				onClick={onRefreshMatch}
+				style={{
+					padding: '5px 12px',
+					borderRadius: 6,
+					border: 'none',
+					background: BRAND,
+					color: '#fff',
+					fontSize: 12,
+					fontWeight: 600,
+					cursor: 'pointer',
+					whiteSpace: 'nowrap',
+				}}
+			>
+				Refresh
+			</button>
+		</div>
+	) : null
+
 	const levelColor = getLevelColor(match.level)
 	const coveredReqs = match.coveredRequirements ?? []
 	const missingReqs = match.missingRequirements ?? []
@@ -509,7 +626,9 @@ export function TruthPanel({
 	const isMismatch = match.level === 'mismatch'
 
 	return (
-		<div style={{ display: 'flex', flexDirection: 'column', height: '100%', padding: '32px 28px', overflow: 'auto' }}>
+		<div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'auto' }}>
+			{refreshBanner}
+			<div style={{ padding: '32px 28px', flex: 1 }}>
 			{/* ═══ VERDICT ═══ */}
 			<div>
 				<div style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: c.dim }}>
@@ -556,7 +675,7 @@ export function TruthPanel({
 						onClick={onSkipRole}
 						style={{ background: 'none', color: c.dim, fontSize: 14, fontWeight: 600, padding: '10px 20px', borderRadius: 10, border: `1px solid ${c.border}`, cursor: 'pointer', width: '100%' }}
 					>
-						Skip this role
+						Skip{selectedJob?.company ? ` ${selectedJob.company}` : ' this role'}
 					</button>
 					{match.skipSuggestion && isMismatch && (
 						<div style={{ fontSize: 13, color: c.dim, marginTop: 4, lineHeight: 1.5 }}>
@@ -658,7 +777,7 @@ export function TruthPanel({
 								width: '100%',
 							}}
 						>
-							Download & apply
+							Download
 						</button>
 						{!hasCoverLetter && (
 							<button
@@ -700,17 +819,88 @@ export function TruthPanel({
 				</div>
 			)}
 
-			{/* ═══ Footer ═══ */}
-			{layer !== 'analysis' && layer !== 'generating' && (
-				<div style={{ marginTop: 'auto', paddingTop: 24 }}>
-					<button
-						onClick={() => setLayer('analysis')}
-						style={{ display: 'flex', alignItems: 'center', gap: 4, background: 'none', border: 'none', color: c.dim, fontSize: 13, cursor: 'pointer', padding: 0 }}
-					>
-						See full analysis <ChevronDown size={12} />
-					</button>
+			{/* ═══ POST-TAILOR LOADING ═══ */}
+			{layer === 'post-tailor-loading' && (
+				<div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '40px 0', gap: 12 }}>
+					<Loader2 size={24} color={BRAND} strokeWidth={2} style={{ animation: 'spin 1s linear infinite' }} />
+					<style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
+					<div style={{ fontSize: 14, color: c.muted, fontWeight: 500 }}>Updating your match score...</div>
 				</div>
 			)}
+
+			{/* ═══ POST-TAILOR RESULT ═══ */}
+			{layer === 'post-tailor-result' && match && (
+				<div style={{ marginTop: 20 }}>
+					<div style={{
+						padding: '16px 20px',
+						borderRadius: 10,
+						background: getLevelColor(match.level) + '10',
+						border: `1px solid ${getLevelColor(match.level)}30`,
+					}}>
+						<div style={{ fontSize: 28, fontWeight: 800, color: getLevelColor(match.level), fontFamily: 'Manrope, sans-serif' }}>
+							{match.level.charAt(0).toUpperCase() + match.level.slice(1)}
+						</div>
+						<div style={{ fontSize: 14, color: c.text, lineHeight: 1.6, marginTop: 8 }}>
+							{match.oneLineSummary || match.summary}
+						</div>
+					</div>
+
+					<div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 20 }}>
+						{!hasCoverLetter && (
+							<button
+								onClick={onGenerateCoverLetter}
+								style={{
+									padding: '10px 16px',
+									borderRadius: 8,
+									border: 'none',
+									background: BRAND,
+									color: '#fff',
+									fontSize: 14,
+									fontWeight: 600,
+									cursor: 'pointer',
+								}}
+							>
+								Write a cover letter
+							</button>
+						)}
+						<button
+							onClick={onDownload}
+							style={{
+								padding: '10px 16px',
+								borderRadius: 8,
+								border: `1px solid ${c.border}`,
+								background: hasCoverLetter ? BRAND : c.bgEl,
+								color: hasCoverLetter ? '#fff' : c.text,
+								fontSize: 14,
+								fontWeight: 600,
+								cursor: 'pointer',
+							}}
+						>
+							Download
+						</button>
+					</div>
+				</div>
+			)}
+
+			{/* ═══ Footer ═══ */}
+			{layer !== 'analysis' && layer !== 'generating' && layer !== 'post-tailor-loading' && layer !== 'post-tailor-result' && (
+				<div style={{ marginTop: 'auto', paddingTop: 24 }}>
+					<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+						<button
+							onClick={() => setLayer('analysis')}
+							style={{ display: 'flex', alignItems: 'center', gap: 4, background: 'none', border: 'none', color: c.dim, fontSize: 13, cursor: 'pointer', padding: 0 }}
+						>
+							See full analysis <ChevronDown size={12} />
+						</button>
+						{lastAddedCount > 0 && (
+							<span style={{ fontSize: 12, color: SUCCESS, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 3 }}>
+								<CheckCircle2 size={12} strokeWidth={2} /> {lastAddedCount} change{lastAddedCount > 1 ? 's' : ''} applied
+							</span>
+						)}
+					</div>
+				</div>
+			)}
+		</div>
 		</div>
 	)
 }

--- a/app/hooks/use-builder-save.ts
+++ b/app/hooks/use-builder-save.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from 'react'
+import { useFetcher } from '@remix-run/react'
+import { useDebouncedCallback } from 'use-debounce'
+import { toast } from '~/components/ui/use-toast.ts'
+import { type ResumeData } from '~/utils/builder-resume.server.ts'
+
+export function useBuilderSave() {
+	const fetcher = useFetcher<{ success: boolean; error?: string }>()
+	const [saveStatus, setSaveStatus] = useState<
+		'idle' | 'saving' | 'saved' | 'error'
+	>('idle')
+	const saveStatusTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
+
+	const debouncedSave = useDebouncedCallback(async (data: ResumeData) => {
+		const form = new FormData()
+		form.append('formData', JSON.stringify(data))
+		form.append('downloadPDFRequested', 'false')
+		form.append('subscribe', 'false')
+		await fetcher.submit(form, {
+			method: 'POST',
+			action: '/resources/save-resume',
+		})
+	}, 1000)
+
+	useEffect(() => {
+		if (fetcher.state === 'submitting') {
+			setSaveStatus('saving')
+			return
+		}
+		if (fetcher.state === 'idle' && fetcher.data) {
+			if (fetcher.data.success === false) {
+				setSaveStatus('error')
+				toast({
+					variant: 'destructive',
+					title: 'Failed to save',
+					description:
+						fetcher.data.error ||
+						'Your changes could not be saved. Please try again.',
+				})
+			} else {
+				setSaveStatus('saved')
+			}
+			clearTimeout(saveStatusTimeoutRef.current)
+			saveStatusTimeoutRef.current = setTimeout(
+				() => setSaveStatus('idle'),
+				3000,
+			)
+		}
+	}, [fetcher.state, fetcher.data])
+
+	return { debouncedSave, saveStatus, saveFetcher: fetcher }
+}

--- a/app/hooks/use-onboarding-flow.ts
+++ b/app/hooks/use-onboarding-flow.ts
@@ -73,7 +73,7 @@ export function useOnboardingFlow({
 	const onboardingStartTime = useRef<number>(Date.now())
 
 	// Local state for session-level overrides
-	const [jobModalDismissed, setJobModalDismissed] = useState(false)
+	const [, setJobModalDismissed] = useState(false)
 	const [sessionTailorComplete, setSessionTailorComplete] = useState(false)
 	const [, setAiModalOpenDuringOnboarding] = useState(false)
 

--- a/app/hooks/use-onboarding-flow.ts
+++ b/app/hooks/use-onboarding-flow.ts
@@ -58,6 +58,8 @@ interface UseOnboardingFlowReturn {
 	handleAIModalClose: () => void
 	/** Handler to call when user clicks "Tailor Achievement" - completes onboarding */
 	handleTailorComplete: () => void
+	/** Reset onboarding state so user can replay the walkthrough */
+	resetOnboarding: () => void
 }
 
 export function useOnboardingFlow({
@@ -97,10 +99,9 @@ export function useOnboardingFlow({
 		sessionTailorComplete,
 	])
 
-	// Show job modal only when:
-	// 1. Stage is needs_job
-	// 2. User hasn't dismissed it this session
-	const showJobModal = stage === 'needs_job' && !jobModalDismissed
+	// #6: Don't auto-trigger the job modal when user starts typing.
+	// The modal should only appear from explicit user action (e.g. "Add Target Job" command).
+	const showJobModal = false
 
 	// Handle job creation from modal
 	const handleJobCreated = useCallback(
@@ -160,6 +161,13 @@ export function useOnboardingFlow({
 		})
 	}, [])
 
+	// Reset onboarding so the walkthrough can be replayed
+	const resetOnboarding = useCallback(() => {
+		setJobModalDismissed(false)
+		setSessionTailorComplete(false)
+		setAiModalOpenDuringOnboarding(false)
+	}, [])
+
 	// Spotlight configuration
 	const spotlightTarget = useMemo(() => getSpotlightTarget(stage), [stage])
 	const spotlightHint = useMemo(() => getSpotlightHint(stage), [stage])
@@ -180,5 +188,6 @@ export function useOnboardingFlow({
 		handleAIModalOpen,
 		handleAIModalClose,
 		handleTailorComplete,
+		resetOnboarding,
 	}
 }

--- a/app/routes/builder+/index.tsx
+++ b/app/routes/builder+/index.tsx
@@ -8,6 +8,9 @@ import {
 	useFetcher,
 	useNavigate,
 	useSubmit,
+	useSearchParams,
+	useRouteError,
+	isRouteErrorResponse,
 } from '@remix-run/react'
 import { useOptionalUser } from '~/utils/user.ts'
 import { useTheme } from '~/routes/resources+/theme/index.tsx'
@@ -31,6 +34,8 @@ import {
 	Eye,
 	EyeOff,
 	Trash2,
+	HelpCircle,
+	RotateCcw,
 } from 'lucide-react'
 import { SubscribeModal } from '~/components/subscribe-modal.tsx'
 import { getStripeSubscription, getUserId } from '~/utils/auth.server.ts'
@@ -75,6 +80,7 @@ import { CoverLetterPanel } from '~/components/cover-letter-panel.tsx'
 import { TEMPLATE_META, FONT_PAIRINGS, COLOR_PALETTE } from '~/utils/templates/registry.ts'
 import { TailorPanel } from '~/components/tailor-panel.tsx'
 import { generateResumeHtml } from '~/utils/generate-resume-html.ts'
+import { useBuilderSave } from '~/hooks/use-builder-save.ts'
 
 function base64ToUint8Array(base64: string): Uint8Array {
 	return Uint8Array.from(atob(base64), c => c.charCodeAt(0))
@@ -491,7 +497,6 @@ function SlideOver({
 					position: 'absolute',
 					inset: 0,
 					background: 'rgba(0,0,0,0.4)',
-					backdropFilter: 'blur(4px)',
 					opacity: visible ? 1 : 0,
 					transition: 'opacity 200ms ease',
 				}}
@@ -563,6 +568,8 @@ export default function ResumeBuilder() {
 	} = useLoaderData<typeof loader>()
 
 	const navigate = useNavigate()
+	const [searchParams] = useSearchParams()
+	const onboardingReset = searchParams.get('onboarding') === 'reset'
 	const [formData, setFormData] = useState(savedData)
 	const appTheme = useTheme()
 	const isDark = appTheme === 'dark'
@@ -572,7 +579,7 @@ export default function ResumeBuilder() {
 	const [showSubscribeModal, setShowSubscribeModal] = useState(false)
 	const [subscribeModalTrigger, setSubscribeModalTrigger] = useState<'download_limit' | 'ai_limit'>('download_limit')
 	const [showCreateJob, setShowCreateJob] = useState(false)
-	const [showCreationModal, setShowCreationModal] = useState(!formData.id)
+	const [showCreationModal, setShowCreationModal] = useState(!formData.id || onboardingReset)
 	const [showAIModal, setShowAIModal] = useState(false)
 	const [aiModalInitialTab, setAiModalInitialTab] = useState<
 		'tailor' | 'generate' | undefined
@@ -603,10 +610,20 @@ export default function ResumeBuilder() {
 	const [cmdSelected, setCmdSelected] = useState(0)
 	const [onboardingDismissed, setOnboardingDismissed] = useState(false)
 	const [onboardingCollapsed, setOnboardingCollapsed] = useState(false)
-	const [hasReviewedMatch, setHasReviewedMatch] = useState(false)
-	const [hasTakenAction, setHasTakenAction] = useState(false)
+	const [hasReviewedMatch, setHasReviewedMatch] = useState(onboardingReset ? false : false)
+	const [hasTakenAction, setHasTakenAction] = useState(onboardingReset ? false : false)
+	const [postTailorMode, setPostTailorMode] = useState(false)
+
+	// ?onboarding=reset: clear coach dismissal so walkthrough replays
+	useEffect(() => {
+		if (onboardingReset) {
+			try { localStorage.removeItem('builder_coach_dismissed') } catch {}
+		}
+	}, [onboardingReset])
 	const [editingResumeId, setEditingResumeId] = useState<string | null>(null)
 	const [matchRefetchKey, setMatchRefetchKey] = useState(0)
+	const [resumeChangedSinceMatch, setResumeChangedSinceMatch] = useState(false)
+	const matchAnalysisVersionRef = useRef(0)
 	const undoSnapshotRef = useRef<typeof formData | null>(null)
 	const skipUndoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 	const bulletUndoMapRef = useRef<Map<string, { action: 'rewrite' | 'new'; experienceId: string; originalText: string | null }>>(new Map())
@@ -740,52 +757,18 @@ export default function ResumeBuilder() {
 	}, [selectedJob?.id])
 
 	/* ═══ SAVE ═══ */
-	const fetcher = useFetcher<{ success: boolean; error?: string }>()
+	const { debouncedSave, saveStatus, saveFetcher: fetcher } = useBuilderSave()
 	const pdfFetcher = useFetcher<{ fileData: string; fileType: string }>()
 	const applicationFetcher = useFetcher()
-	const [saveStatus, setSaveStatus] = useState<
-		'idle' | 'saving' | 'saved' | 'error'
-	>('idle')
-	const saveStatusTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
 	const scrollHighlightTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
-
-	const debouncedSave = useDebouncedCallback(async (data: ResumeData) => {
-		const form = new FormData()
-		form.append('formData', JSON.stringify(data))
-		form.append('downloadPDFRequested', 'false')
-		form.append('subscribe', 'false')
-		await fetcher.submit(form, {
-			method: 'POST',
-			action: '/resources/save-resume',
-		})
-	}, 1000)
 	debouncedSaveRef.current = debouncedSave
 
+	// #28-29: Track when resume changes after last match analysis
 	useEffect(() => {
-		if (fetcher.state === 'submitting') {
-			setSaveStatus('saving')
-			return
+		if (saveStatus === 'saved' && matchAnalysisVersionRef.current > 0) {
+			setResumeChangedSinceMatch(true)
 		}
-		if (fetcher.state === 'idle' && fetcher.data) {
-			if (fetcher.data.success === false) {
-				setSaveStatus('error')
-				toast({
-					variant: 'destructive',
-					title: 'Failed to save',
-					description:
-						fetcher.data.error ||
-						'Your changes could not be saved. Please try again.',
-				})
-			} else {
-				setSaveStatus('saved')
-			}
-			clearTimeout(saveStatusTimeoutRef.current)
-			saveStatusTimeoutRef.current = setTimeout(
-				() => setSaveStatus('idle'),
-				3000,
-			)
-		}
-	}, [fetcher.state, fetcher.data])
+	}, [saveStatus])
 
 	/* ═══ TAILOR PANEL ═══ */
 	// Check for existing snapshot on load
@@ -997,42 +980,46 @@ export default function ResumeBuilder() {
 	}
 
 	const addBulletPoint = (experienceId: string) => {
-		if (!formData.experiences) return
-		const newFormData = {
-			...formData,
-			experiences: formData.experiences.map(exp => {
-				if (exp.id !== experienceId) return exp
-				return {
-					...exp,
-					descriptions: [
-						...(exp.descriptions || []),
-						{ id: crypto.randomUUID(), content: '' },
-					],
-				}
-			}),
-		}
-		setFormData(newFormData)
-		debouncedSave(newFormData)
+		setFormData(prev => {
+			if (!prev.experiences) return prev
+			const newFormData = {
+				...prev,
+				experiences: prev.experiences.map(exp => {
+					if (exp.id !== experienceId) return exp
+					return {
+						...exp,
+						descriptions: [
+							...(exp.descriptions || []),
+							{ id: crypto.randomUUID(), content: '' },
+						],
+					}
+				}),
+			}
+			debouncedSave(newFormData)
+			return newFormData
+		})
 	}
 
 	const deleteBullet = (experienceId: string, bulletIndex: number) => {
-		if (!formData.experiences) return
-		const newFormData = {
-			...formData,
-			experiences: formData.experiences.map(exp => {
-				if (exp.id !== experienceId || !exp.descriptions) return exp
-				const filtered = exp.descriptions.filter((_, i) => i !== bulletIndex)
-				return {
-					...exp,
-					descriptions:
-						filtered.length > 0
-							? filtered
-							: [{ id: crypto.randomUUID(), content: '' }],
-				}
-			}),
-		}
-		setFormData(newFormData)
-		debouncedSave(newFormData)
+		setFormData(prev => {
+			if (!prev.experiences) return prev
+			const newFormData = {
+				...prev,
+				experiences: prev.experiences.map(exp => {
+					if (exp.id !== experienceId || !exp.descriptions) return exp
+					const filtered = exp.descriptions.filter((_, i) => i !== bulletIndex)
+					return {
+						...exp,
+						descriptions:
+							filtered.length > 0
+								? filtered
+								: [{ id: crypto.randomUUID(), content: '' }],
+					}
+				}),
+			}
+			debouncedSave(newFormData)
+			return newFormData
+		})
 	}
 
 	const reorderBullets = (
@@ -1040,19 +1027,22 @@ export default function ResumeBuilder() {
 		oldIndex: number,
 		newIndex: number,
 	) => {
-		if (!formData.experiences) return
-		const newFormData = {
-			...formData,
-			experiences: formData.experiences.map(exp => {
-				if (exp.id !== experienceId || !exp.descriptions) return exp
-				return {
-					...exp,
-					descriptions: moveArray(exp.descriptions, oldIndex, newIndex),
-				}
-			}),
-		}
-		setFormData(newFormData)
-		debouncedSave(newFormData)
+		setFormData(prev => {
+			if (!prev.experiences) return prev
+			const newFormData = {
+				...prev,
+				experiences: prev.experiences.map(exp => {
+					if (exp.id !== experienceId || !exp.descriptions) return exp
+					return {
+						...exp,
+						descriptions: moveArray(exp.descriptions, oldIndex, newIndex),
+					}
+				}),
+			}
+			debouncedSave(newFormData)
+			iframeComponentRef.current?.markStructuralUpdate()
+			return newFormData
+		})
 	}
 
 	const updateEduField = (
@@ -1284,7 +1274,6 @@ export default function ResumeBuilder() {
 			// Blank resume — just attach job directly, no clone needed
 			if (isResumeBlank(formData)) {
 				setSelectedJob(job)
-				setSidebar(false)
 				const newFormData = { ...formData, jobId: job.id, job }
 				setFormData(newFormData)
 				debouncedSave(newFormData)
@@ -1305,7 +1294,6 @@ export default function ResumeBuilder() {
 
 			// Clone the current resume for this job
 			setSelectedJob(job)
-			setSidebar(false)
 
 			cloneForJobFetcher.submit(
 				{
@@ -1457,19 +1445,19 @@ export default function ResumeBuilder() {
 	const coachSteps = useMemo(
 		() => [
 			{
-				title: 'Reorder sections',
-				body: 'Hover over section headers to reorder, add items, or toggle visibility.',
+				title: 'Edit your resume',
+				body: 'Hover over any text in the resume to edit it directly. Bullet points show a toolbar on hover.',
 				anchor: 'iframe' as const,
 			},
 			{
 				title: 'Customize appearance',
-				body: 'Change fonts, colors, text size, and layout templates from the Customize panel.',
-				anchor: 'customize' as const,
+				body: 'Open Quick Actions (Ctrl+K) and search "Customize" to change fonts, colors, and layout.',
+				anchor: 'nav' as const,
 			},
 			{
 				title: 'AI-powered tailoring',
-				body: 'Match your resume to a specific job description with one click.',
-				anchor: 'tailor' as const,
+				body: 'Add a target job, then hover a bullet and click the purple AI button to tailor it.',
+				anchor: 'iframe' as const,
 			},
 		],
 		[],
@@ -1709,8 +1697,18 @@ export default function ResumeBuilder() {
 				icon: Briefcase,
 				action: () => setShowCreateJob(true),
 			},
+			{
+				id: 'replay-walkthrough',
+				label: 'Replay Walkthrough',
+				icon: RotateCcw,
+				action: () => {
+					onboarding.resetOnboarding()
+					localStorage.removeItem('builder_coach_dismissed')
+					setCoachStep(0)
+				},
+			},
 		],
-		[isDark, toggleDarkMode, handleClickDownloadPDF],
+		[isDark, toggleDarkMode, handleClickDownloadPDF, onboarding],
 	)
 
 	const filteredCommands = cmdSearch
@@ -1814,6 +1812,17 @@ export default function ResumeBuilder() {
 	/* ═══ IFRAME HANDLERS ═══ */
 	const handleIframeFieldChange = useCallback(
 		(fieldPath: string, value: string) => {
+			// #12: Update section highlighting to follow editing
+			if (['name', 'role', 'email', 'phone', 'location', 'website', 'about'].includes(fieldPath) || fieldPath.startsWith('headers.about')) {
+				setActiveSection('summary')
+			} else if (fieldPath.startsWith('experiences.') || fieldPath.startsWith('headers.experience')) {
+				setActiveSection('experience')
+			} else if (fieldPath.startsWith('education.') || fieldPath.startsWith('headers.education')) {
+				setActiveSection('education')
+			} else if (fieldPath.startsWith('skills.') || fieldPath.startsWith('headers.skills')) {
+				setActiveSection('skills')
+			}
+
 			if (
 				[
 					'name',
@@ -1958,6 +1967,7 @@ export default function ResumeBuilder() {
 			const bullet = exp.descriptions?.[bulletIndex]
 			handleAIClick(experienceId, bulletIndex, bullet?.content || '')
 			setHoveredElement(null)
+			setHasTakenAction(true)
 		},
 		[formData, handleAIClick],
 	)
@@ -2086,6 +2096,11 @@ export default function ResumeBuilder() {
 				manageSubFormRef={manageSubFormRef}
 				submitForm={submitForm}
 				navigate={navigate}
+				onReplayWalkthrough={() => {
+					onboarding.resetOnboarding()
+					localStorage.removeItem('builder_coach_dismissed')
+					setCoachStep(0)
+				}}
 				BRAND={BRAND}
 				AMBER={AMBER}
 				SUCCESS={SUCCESS}
@@ -2345,13 +2360,32 @@ export default function ResumeBuilder() {
 									Target Job
 								</span>
 								{jobs.length > 0 && (
-									<div style={{ marginTop: 9 }}>
-										<JobDropdown
-											jobs={jobs}
-											current={formData.jobId ?? null}
-											onSelect={handleJobChange}
-											c={c}
-										/>
+									<div style={{ marginTop: 9, display: 'flex', alignItems: 'center', gap: 4 }}>
+										<div style={{ flex: 1 }}>
+											<JobDropdown
+												jobs={jobs}
+												current={formData.jobId ?? null}
+												onSelect={handleJobChange}
+												c={c}
+											/>
+										</div>
+										{selectedJob && (
+											<button
+												onClick={() => {
+													if (!selectedJob.id || !confirm(`Remove "${selectedJob.company || selectedJob.title || 'this job'}" from your target jobs?`)) return
+													const fd = new FormData()
+													fd.append('jobid', selectedJob.id)
+													fetch('/resources/delete-job', { method: 'POST', body: fd })
+													setSelectedJob(null)
+													setFormData(prev => ({ ...prev, jobId: undefined, job: undefined }))
+												}}
+												title="Remove target job"
+												style={{ padding: 4, cursor: 'pointer', color: c.muted, background: 'transparent', border: 'none', borderRadius: 4 }}
+												className="hover-brand"
+											>
+												<Trash2 size={14} />
+											</button>
+										)}
 									</div>
 								)}
 								<div
@@ -2546,6 +2580,22 @@ export default function ResumeBuilder() {
 							))}
 						</div>
 					)}
+
+					{/* ═══ ONBOARDING WIDGET (inline in sidebar) ═══ */}
+					{sidebar && !showCreationModal && <OnboardingWidget
+						isComplete={onboarding.isComplete}
+						dismissed={onboardingDismissed}
+						collapsed={onboardingCollapsed}
+						setDismissed={setOnboardingDismissed}
+						setCollapsed={setOnboardingCollapsed}
+						hasResume={!!(formData.name || formData.role)}
+						hasJob={!!selectedJob}
+						hasReviewedMatch={hasReviewedMatch}
+						hasTakenAction={hasTakenAction}
+						onResumeClick={() => scrollToSection('summary')}
+						onJobClick={() => setShowCreateJob(true)}
+						c={c}
+					/>}
 				</div>
 
 				{/* CENTER CANVAS */}
@@ -2607,6 +2657,33 @@ export default function ResumeBuilder() {
 				</div>
 
 				{/* SCORE PANEL */}
+				{!scorePanel && (
+					<button
+						onClick={() => setScorePanel(true)}
+						style={{
+							position: 'absolute',
+							right: 0,
+							top: '50%',
+							transform: 'translateY(-50%)',
+							background: c.bgEl,
+							border: `1px solid ${c.border}`,
+							borderRight: 'none',
+							borderRadius: '8px 0 0 8px',
+							padding: '12px 6px',
+							cursor: 'pointer',
+							zIndex: 10,
+							display: 'flex',
+							flexDirection: 'column',
+							alignItems: 'center',
+							gap: 4,
+							boxShadow: '-2px 0 8px rgba(0,0,0,0.05)',
+						}}
+						title="Show match analysis"
+					>
+						<Target size={16} color={c.dim} />
+						<span style={{ fontSize: 10, color: c.muted, writingMode: 'vertical-rl', textOrientation: 'mixed' }}>Match</span>
+					</button>
+				)}
 				{scorePanel && (
 					<div
 						style={{
@@ -2653,11 +2730,23 @@ export default function ResumeBuilder() {
 							selectedJob={selectedJob ?? null}
 							theme={c}
 							refetchKey={matchRefetchKey}
+							resumeChanged={resumeChangedSinceMatch}
+							postTailorMode={postTailorMode}
+							onRefreshMatch={() => {
+								setMatchRefetchKey(k => k + 1)
+								setResumeChangedSinceMatch(false)
+								matchAnalysisVersionRef.current += 1
+							}}
 							onGenerateCoverLetter={() => {
 								setHasTakenAction(true)
 								handleGenerateCoverLetter()
 							}}
-							onMatchLoaded={() => setHasReviewedMatch(true)}
+							onMatchLoaded={() => {
+								setHasReviewedMatch(true)
+								matchAnalysisVersionRef.current += 1
+								setResumeChangedSinceMatch(false)
+								if (postTailorMode) setPostTailorMode(false)
+							}}
 							onBulletsGenerated={(changes, gaps, summary) => {
 								setHasTakenAction(true)
 								const snapshot = structuredClone(formData)
@@ -2720,7 +2809,9 @@ export default function ResumeBuilder() {
 									title: `Updated ${changes.length} bullet${changes.length > 1 ? 's' : ''}${summary ? ' + summary' : ''}`,
 									description: 'See changes highlighted on your resume.',
 								})
-								setMatchRefetchKey(k => k + 1)
+								// Trigger post-tailor re-analysis (summary only, no conversation)
+								setPostTailorMode(true)
+								setResumeChangedSinceMatch(false)
 							}}
 							onUndoBullets={undoSnapshotRef.current ? () => {
 								if (undoSnapshotRef.current) {
@@ -3249,16 +3340,14 @@ export default function ResumeBuilder() {
 			{coachStep !== null && (() => {
 				const step = coachSteps[coachStep]
 				if (!step) return null
-				let anchorRect: { top: number; left: number; width: number; height: number } | null = null
-				if (step.anchor === 'customize' && customizeBtnRef.current) {
-					anchorRect = customizeBtnRef.current.getBoundingClientRect()
-				} else if (step.anchor === 'tailor' && tailorBtnRef.current) {
-					anchorRect = tailorBtnRef.current.getBoundingClientRect()
-				} else if (step.anchor === 'iframe') {
-					// Point at the resume area (upper-left of main content)
+				let anchorRect: { top: number; left: number; width: number; height: number }
+				if (step.anchor === 'nav') {
+					// Point at the search/quick actions bar area in the nav
+					anchorRect = { top: 8, left: window.innerWidth / 2 - 100, width: 200, height: 40 }
+				} else {
+					// Point at the resume area (center of main content)
 					anchorRect = { top: 120, left: window.innerWidth / 2 - 100, width: 200, height: 0 }
 				}
-				if (!anchorRect) return null
 				const tooltipTop = anchorRect.top + anchorRect.height + 12
 				const tooltipLeft = Math.max(16, Math.min(anchorRect.left + anchorRect.width / 2 - 140, window.innerWidth - 296))
 				return (
@@ -3333,21 +3422,40 @@ export default function ResumeBuilder() {
 				)
 			})()}
 
-			{/* ═══ ONBOARDING WIDGET ═══ */}
-			<OnboardingWidget
-				isComplete={onboarding.isComplete}
-				dismissed={onboardingDismissed}
-				collapsed={onboardingCollapsed}
-				setDismissed={setOnboardingDismissed}
-				setCollapsed={setOnboardingCollapsed}
-				hasResume={!!(formData.name || formData.role)}
-				hasJob={!!selectedJob}
-				hasReviewedMatch={hasReviewedMatch}
-				hasTakenAction={hasTakenAction}
-				onResumeClick={() => scrollToSection('summary')}
-				onJobClick={() => setShowCreateJob(true)}
-				c={c}
-			/>
+		</div>
+	)
+}
+
+export function ErrorBoundary() {
+	const error = useRouteError()
+
+	let heading = 'Something went wrong'
+	let message = 'An unexpected error occurred in the builder.'
+
+	if (isRouteErrorResponse(error)) {
+		heading = `${error.status} ${error.statusText}`
+		message = error.data?.message || error.data || 'The server returned an error.'
+	} else if (error instanceof Error) {
+		message = error.message
+	}
+
+	return (
+		<div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+			<div className="w-full max-w-md rounded-lg bg-white p-8 text-center shadow-lg dark:bg-gray-800">
+				<div className="mb-4 text-4xl">⚠</div>
+				<h1 className="mb-2 text-xl font-semibold text-gray-900 dark:text-gray-100">
+					{heading}
+				</h1>
+				<p className="mb-6 text-sm text-gray-600 dark:text-gray-400">
+					{message}
+				</p>
+				<button
+					onClick={() => window.location.reload()}
+					className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+				>
+					Reload page
+				</button>
+			</div>
 		</div>
 	)
 }

--- a/app/routes/builder+/index.tsx
+++ b/app/routes/builder+/index.tsx
@@ -857,6 +857,7 @@ export default function ResumeBuilder() {
 	)
 
 	const deleteFetcher = useFetcher()
+	const deleteJobFetcher = useFetcher()
 	const handleDeleteResume = useCallback(
 		(e: React.MouseEvent, resumeId: string) => {
 			e.stopPropagation()
@@ -976,20 +977,23 @@ export default function ResumeBuilder() {
 		})
 	}
 
-	const addBulletPoint = (experienceId: string) => {
+	const addBulletPoint = (experienceId: string, afterIndex?: number) => {
 		setFormData(prev => {
 			if (!prev.experiences) return prev
 			const newFormData = {
 				...prev,
 				experiences: prev.experiences.map(exp => {
 					if (exp.id !== experienceId) return exp
-					return {
-						...exp,
-						descriptions: [
-							...(exp.descriptions || []),
-							{ id: crypto.randomUUID(), content: '' },
-						],
-					}
+					const current = exp.descriptions || []
+					const newBullet = { id: crypto.randomUUID(), content: '' }
+					const insertAt =
+						afterIndex === undefined ? current.length : afterIndex + 1
+					const descriptions = [
+						...current.slice(0, insertAt),
+						newBullet,
+						...current.slice(insertAt),
+					]
+					return { ...exp, descriptions }
 				}),
 			}
 			debouncedSave(newFormData)
@@ -1258,7 +1262,6 @@ export default function ResumeBuilder() {
 			if (existingForJob && existingForJob.id !== formData.id) {
 				handleResumeSwitch(existingForJob.id!)
 				setSelectedJob(job)
-				setSidebar(false)
 				trackLegacyEvent('job_selected', {
 					jobId: job.id,
 					hasJobDescription: !!(job?.content && job.content.trim().length > 0),
@@ -1330,7 +1333,7 @@ export default function ResumeBuilder() {
 		setSelectedExperience(experience)
 		setSelectedBullet({ content, experienceId, bulletIndex })
 		setDiagnosticContext(diagnostic ?? null)
-		setAiModalInitialTab(undefined)
+		setAiModalInitialTab(content.trim() ? undefined : 'generate')
 		setShowAIModal(true)
 		onboarding.handleAIModalOpen()
 	}
@@ -1893,7 +1896,7 @@ export default function ResumeBuilder() {
 			iframeComponentRef.current?.markStructuralUpdate()
 			switch (action.type) {
 				case 'addBullet':
-					addBulletPoint(action.experienceId)
+					addBulletPoint(action.experienceId, action.afterIndex)
 					break
 				case 'deleteBullet':
 					deleteBullet(action.experienceId, action.bulletIndex)
@@ -2358,7 +2361,7 @@ export default function ResumeBuilder() {
 								</span>
 								{jobs.length > 0 && (
 									<div style={{ marginTop: 9, display: 'flex', alignItems: 'center', gap: 4 }}>
-										<div style={{ flex: 1 }}>
+										<div style={{ flex: 1, minWidth: 0 }}>
 											<JobDropdown
 												jobs={jobs}
 												current={formData.jobId ?? null}
@@ -2372,7 +2375,10 @@ export default function ResumeBuilder() {
 													if (!selectedJob.id || !confirm(`Remove "${selectedJob.company || selectedJob.title || 'this job'}" from your target jobs?`)) return
 													const fd = new FormData()
 													fd.append('jobid', selectedJob.id)
-													fetch('/resources/delete-job', { method: 'POST', body: fd })
+													deleteJobFetcher.submit(fd, {
+														method: 'POST',
+														action: '/resources/delete-job',
+													})
 													setSelectedJob(null)
 													setFormData(prev => ({ ...prev, jobId: undefined, job: undefined }))
 												}}
@@ -3343,6 +3349,7 @@ export default function ResumeBuilder() {
 
 			{/* ═══ COACH MARKS ═══ */}
 			{coachStep !== null && (() => {
+				if (showCreationModal) return null
 				const step = coachSteps[coachStep]
 				if (!step) return null
 				let anchorRect: { top: number; left: number; width: number; height: number }

--- a/app/routes/builder+/index.tsx
+++ b/app/routes/builder+/index.tsx
@@ -34,12 +34,11 @@ import {
 	Eye,
 	EyeOff,
 	Trash2,
-	HelpCircle,
 	RotateCcw,
 } from 'lucide-react'
 import { SubscribeModal } from '~/components/subscribe-modal.tsx'
 import { getStripeSubscription, getUserId } from '~/utils/auth.server.ts'
-import { useDebouncedCallback } from 'use-debounce'
+// useDebouncedCallback moved to use-builder-save hook
 import { resumeCookie } from '~/utils/resume-cookie.server.ts'
 import {
 	AIAssistantModal,
@@ -629,8 +628,6 @@ export default function ResumeBuilder() {
 	const bulletUndoMapRef = useRef<Map<string, { action: 'rewrite' | 'new'; experienceId: string; originalText: string | null }>>(new Map())
 	const [pendingHighlights, setPendingHighlights] = useState<string[]>([])
 	const [coachStep, setCoachStep] = useState<number | null>(null)
-	const customizeBtnRef = useRef<HTMLButtonElement>(null)
-	const tailorBtnRef = useRef<HTMLButtonElement>(null)
 	const [tailorPanelOpen, setTailorPanelOpen] = useState(false)
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [_hasTailorSnapshot, setHasTailorSnapshot] = useState(false)

--- a/app/routes/resources+/delete-job.tsx
+++ b/app/routes/resources+/delete-job.tsx
@@ -10,6 +10,7 @@ import { ErrorList } from '~/components/forms.tsx'
 
 const DeleteFormSchema = z.object({
 	jobid: z.string(),
+	redirectTo: z.string().optional(),
 })
 
 export async function action({ request }: DataFunctionArgs) {
@@ -29,7 +30,7 @@ export async function action({ request }: DataFunctionArgs) {
 		)
 	}
 
-	const { jobid } = submission.value
+	const { jobid, redirectTo } = submission.value
 
 	const job = await prisma.job.findFirst({
 		select: { id: true, owner: { select: { username: true } } },
@@ -49,7 +50,8 @@ export async function action({ request }: DataFunctionArgs) {
 		where: { id: job.id },
 	})
 
-	return redirect(`/jobs`)
+	if (redirectTo) return redirect(redirectTo)
+	return json({ status: 'success', submission } as const)
 }
 
 export function DeleteJob({ id }: { id: string }) {
@@ -70,6 +72,7 @@ export function DeleteJob({ id }: { id: string }) {
 			{...form.props}
 		>
 			<input type="hidden" name="jobid" value={id} />
+			<input type="hidden" name="redirectTo" value="/jobs" />
 			<Button
 				type="submit"
 				variant="danger"

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -384,3 +384,8 @@
   size: letter;
   margin: 0;
 }
+
+/* Hide reCAPTCHA badge — attribution text required in footer per Google ToS */
+.grecaptcha-badge {
+  visibility: hidden !important;
+}

--- a/app/utils/builder-resume.server.ts
+++ b/app/utils/builder-resume.server.ts
@@ -112,7 +112,7 @@ export async function createBuilderResume(
 									content: descData.content ?? '',
 									order: descData.order ?? index,
 								}
-							}).filter(desc => desc.content !== '') ?? [],
+							}) ?? [],
 						},
 					}
 				}) || [],

--- a/app/utils/templates/editorial.ts
+++ b/app/utils/templates/editorial.ts
@@ -163,6 +163,12 @@ export function generate(
 		[data-education-id] {
 			break-inside: avoid;
 		}
+		li span[contenteditable]:empty::before {
+			content: 'Add a bullet point...';
+			color: #9CA3AF;
+			font-style: italic;
+			pointer-events: none;
+		}
 		@media print {
 			.page-gap { display: none; }
 		}${options.editable ? getEditableCss() : ''}

--- a/app/utils/templates/modernist.ts
+++ b/app/utils/templates/modernist.ts
@@ -156,6 +156,12 @@ export function generate(
 		[data-education-id] {
 			break-inside: avoid;
 		}
+		li span[contenteditable]:empty::before {
+			content: 'Add a bullet point...';
+			color: #9CA3AF;
+			font-style: italic;
+			pointer-events: none;
+		}
 		@media print {
 			.page-gap { display: none; }
 		}${options.editable ? getEditableCss() : ''}

--- a/app/utils/templates/simple.ts
+++ b/app/utils/templates/simple.ts
@@ -179,6 +179,12 @@ export function generate(
 		[data-education-id] {
 			break-inside: avoid;
 		}
+		li span[contenteditable]:empty::before {
+			content: 'Add a bullet point...';
+			color: #9CA3AF;
+			font-style: italic;
+			pointer-events: none;
+		}
 		@media print {
 			.page-gap {
 				display: none;

--- a/app/utils/templates/slate.ts
+++ b/app/utils/templates/slate.ts
@@ -167,6 +167,12 @@ export function generate(
 		[data-education-id] {
 			break-inside: avoid;
 		}
+		li span[contenteditable]:empty::before {
+			content: 'Add a bullet point...';
+			color: #9CA3AF;
+			font-style: italic;
+			pointer-events: none;
+		}
 		@media print {
 			.page-gap { display: none; }
 		}${options.editable ? getEditableCss() : ''}

--- a/app/utils/templates/warm.ts
+++ b/app/utils/templates/warm.ts
@@ -162,6 +162,12 @@ export function generate(
 		[data-education-id] {
 			break-inside: avoid;
 		}
+		li span[contenteditable]:empty::before {
+			content: 'Add a bullet point...';
+			color: #9CA3AF;
+			font-style: italic;
+			pointer-events: none;
+		}
 		@media print {
 			.page-gap { display: none; }
 		}${options.editable ? getEditableCss() : ''}

--- a/app/utils/z-index.ts
+++ b/app/utils/z-index.ts
@@ -1,0 +1,21 @@
+// Z-index scale for consistent layering across the app
+// base(0-9): inline elements within panels
+// dropdown(10-19): dropdowns, tooltips
+// panel(20-49): slide-out panels, overlays within builder
+// toolbar(50-99): floating toolbar, action bars
+// nav(100-149): navigation, persistent UI
+// widget(150-199): onboarding widget, non-blocking overlays
+// modal(200-249): all modals (subscribe, creation, job, AI assistant)
+// system(250-299): system-level overlays (spotlight, error boundaries)
+
+export const Z_INDEX = {
+  base: 'z-0',
+  dropdown: 'z-10',
+  panel: 'z-20',
+  toolbar: 'z-50',
+  nav: 'z-[100]',
+  widget: 'z-[150]',
+  modal: 'z-[200]',
+  modalBackdrop: 'z-[199]',
+  system: 'z-[250]',
+} as const

--- a/prisma/migrations/20260408020754_fix_job_cascade_to_set_null/migration.sql
+++ b/prisma/migrations/20260408020754_fix_job_cascade_to_set_null/migration.sql
@@ -1,0 +1,42 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `blockTree` on the `BuilderResume` table. All the data in the column will be lost.
+  - You are about to drop the column `sourceFileId` on the `BuilderResume` table. All the data in the column will be lost.
+  - You are about to drop the column `sourceFormat` on the `BuilderResume` table. All the data in the column will be lost.
+  - You are about to drop the column `templateHtml` on the `BuilderResume` table. All the data in the column will be lost.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_BuilderResume" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "userId" TEXT,
+    "jobId" TEXT,
+    "name" TEXT,
+    "role" TEXT,
+    "email" TEXT,
+    "phone" TEXT,
+    "location" TEXT,
+    "website" TEXT,
+    "about" TEXT,
+    "image" TEXT,
+    "nameColor" TEXT,
+    "font" TEXT,
+    "layout" TEXT,
+    "textSize" TEXT,
+    "coverLetterDrafts" TEXT,
+    "tailorSnapshot" TEXT,
+    "tailorSnapshotDate" DATETIME,
+    CONSTRAINT "BuilderResume_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "BuilderResume_jobId_fkey" FOREIGN KEY ("jobId") REFERENCES "Job" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_BuilderResume" ("about", "coverLetterDrafts", "createdAt", "email", "font", "id", "image", "jobId", "layout", "location", "name", "nameColor", "phone", "role", "tailorSnapshot", "tailorSnapshotDate", "textSize", "updatedAt", "userId", "website") SELECT "about", "coverLetterDrafts", "createdAt", "email", "font", "id", "image", "jobId", "layout", "location", "name", "nameColor", "phone", "role", "tailorSnapshot", "tailorSnapshotDate", "textSize", "updatedAt", "userId", "website" FROM "BuilderResume";
+DROP TABLE "BuilderResume";
+ALTER TABLE "new_BuilderResume" RENAME TO "BuilderResume";
+CREATE INDEX "BuilderResume_userId_idx" ON "BuilderResume"("userId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -269,7 +269,7 @@ model BuilderResume {
   textSize        String?
   visibleSections BuilderVisibleSections?
   user            User?                   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  job             Job?                    @relation(fields: [jobId], references: [id], onDelete: Cascade)
+  job             Job?                    @relation(fields: [jobId], references: [id], onDelete: SetNull)
   experiences     BuilderExperience[]
   education       BuilderEducation[]
   skills          BuilderSkill[]


### PR DESCRIPTION
Wave 0: Error boundary, z-index scale, save status bug, useBuilderSave
hook extraction, job cascade migration (onDelete: Cascade → SetNull)

Wave 1: Kill double popup (#1), empty resume mismatch guard (#10), upload error handling with validation (#11), toolbar persistence with coordinated timeout (#18), subscribe modal z-index fix (#24), OS-aware shortcuts (#15)

Wave 2: Bullet reorder race condition fix — callback pattern in reorderBullets/addBullet/deleteBullet (#17), bullet placeholder CSS in all 5 templates (#16), AI tailor button persistent purple + label (#19), sidebar stays open on job attach/clone (#9)

Wave 3: Match refresh banner (#28-29), section highlighting follows editing (#12), post-tailor auto re-analysis — skips conversation, shows summary-only score update

Wave 4: Onboarding widget moved inline to sidebar with shimmer animation, replay walkthrough via command palette + help button (#2), locked onboarding steps (#4), match panel toggle tab (#36), auto-expand recommendations (#31)

Wave 5: Captcha badge hidden (#27), delete target job button (#7), cover letter text labels (#38-40), remove customize blur (#13), button text cleanup (#14), skip with job name (#32), loading text (#30), generate/rewrite label (#21), disable job modal auto-trigger (#6)

Additional: ?onboarding=reset URL param for testing, WCAG AAA contrast on getting started widget, horizontal toolbar layout

<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
